### PR TITLE
Add caching tests for loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/sarvabhasha_tts/sarvabhasha_tts/api/server.py
+++ b/sarvabhasha_tts/sarvabhasha_tts/api/server.py
@@ -11,11 +11,13 @@ app = FastAPI(title="Sarvabhasha TTS")
 
 # Dynamically load pipeline instances
 _instances = {}
-def _get(name, *args):
+
+def _get(name, *args, **kwargs):
+    """Return cached pipeline instance, creating it if needed."""
     if name not in _instances:
         module_path, cls_name = config.PIPELINES[name].split(":")
         cls = getattr(import_module(module_path), cls_name)
-        _instances[name] = cls(*args)
+        _instances[name] = cls(*args, **kwargs)
     return _instances[name]
 
 class TTSRequest(BaseModel):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "sarvabhasha_tts")))
+
+# Provide a minimal fake torch module so config can be imported without real dependencies
+fake_torch = types.ModuleType("torch")
+fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+sys.modules.setdefault("torch", fake_torch)
+
+from sarvabhasha_tts.api import server
+
+class Dummy:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+def test_get_caches_instance(monkeypatch):
+    # Use Dummy class for pipeline and reset cache
+    monkeypatch.setitem(server.config.PIPELINES, "dummy", "tests.test_loader:Dummy")
+    server._instances.clear()
+
+    first = server._get("dummy")
+    second = server._get("dummy")
+    assert first is second
+
+def test_get_accepts_kwargs(monkeypatch):
+    monkeypatch.setitem(server.config.PIPELINES, "acoustic", "tests.test_loader:Dummy")
+    server._instances.clear()
+    inst = server._get("acoustic", device="cpu")
+    assert isinstance(inst, Dummy)


### PR DESCRIPTION
## Summary
- add pytest configuration
- support kwargs in `_get`
- test loader caching and kwargs handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840110163b0832dbb0d1f00d7c572a7