### PR TITLE
Fix language identification call

### DIFF
--- a/sarvabhasha_tts/sarvabhasha_tts/api/server.py
+++ b/sarvabhasha_tts/sarvabhasha_tts/api/server.py
@@ -25,7 +25,7 @@ class TTSRequest(BaseModel):
 @app.post("/synth")
 async def synthesise(req: TTSRequest, speaker: UploadFile = File(None)):
     # 1. Lang ID (if lang="auto")
-    lang = req.lang if req.lang != "auto" else _get("langid")([req.text])
+    lang = req.lang if req.lang != "auto" else _get("langid")(req.text)
 
     # 2. Tokenise, normalise, transliterate
     toks = _get("tokenizer", lang)(req.text)


### PR DESCRIPTION
## Summary
- fix FastTextLangID invocation in API server

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68412ff899dc832db74763423bf3155a